### PR TITLE
Review of Argo CD approach

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     path: apps
     repoURL: https://github.com/epics-containers/bl45p-apps.git
-    targetRevision: main
+    targetRevision: review
     helm:
       version: v3
   syncPolicy:

--- a/apps/templates/all_apps.yaml
+++ b/apps/templates/all_apps.yaml
@@ -16,7 +16,7 @@ spec:
     name: {{ $currentScope.Values.destination.name }}
   source:
     repoURL: {{ default $currentScope.Values.source.repoURL $settings.repoURL }}
-    path: {{ services/$service }}
+    path: {{ "services/"$service }}
     targetRevision: {{ default $currentScope.Values.source.targetRevision $settings.targetRevision }}
     helm:
       version: v3

--- a/apps/templates/all_apps.yaml
+++ b/apps/templates/all_apps.yaml
@@ -35,9 +35,6 @@ spec:
         - name: global.enabled
           value: {{ eq $settings.enabled false | ternary false true | quote }}
       {{- if $settings.values }}
-      values: |
-{{ toYaml $settings.values | indent 8 }}
-      {{- end }}
   syncPolicy:
     automated:
       prune: true

--- a/apps/templates/all_apps.yaml
+++ b/apps/templates/all_apps.yaml
@@ -16,7 +16,7 @@ spec:
     name: {{ $currentScope.Values.destination.name }}
   source:
     repoURL: {{ default $currentScope.Values.source.repoURL $settings.repoURL }}
-    path: "services/"{{ $service }}
+    path: services/{{ $service }}
     targetRevision: {{ default $currentScope.Values.source.targetRevision $settings.targetRevision }}
     helm:
       version: v3

--- a/apps/templates/all_apps.yaml
+++ b/apps/templates/all_apps.yaml
@@ -16,7 +16,7 @@ spec:
     name: {{ $currentScope.Values.destination.name }}
   source:
     repoURL: {{ default $currentScope.Values.source.repoURL $settings.repoURL }}
-    path: services/{{ default $service $settings.folder }}
+    path: services/$service
     targetRevision: {{ default $currentScope.Values.source.targetRevision $settings.targetRevision }}
     helm:
       version: v3

--- a/apps/templates/all_apps.yaml
+++ b/apps/templates/all_apps.yaml
@@ -34,7 +34,6 @@ spec:
       parameters:
         - name: global.enabled
           value: {{ eq $settings.enabled false | ternary false true | quote }}
-      {{- if $settings.values }}
   syncPolicy:
     automated:
       prune: true

--- a/apps/templates/all_apps.yaml
+++ b/apps/templates/all_apps.yaml
@@ -23,10 +23,12 @@ spec:
       valueFiles:
         - ../beamline_values.yaml
         - values.yaml
-      {{-  range $settings.files  }}
+      {{- if $settings.files }}
       fileParameters:
+      {{-  range $settings.files  }}
         - name: global.files.{{ . | replace "." "_dot_" }}
           path: config/{{ . }}
+      {{- end -}}
       {{- end }}
       {{- if eq $settings.enabled false }}
       parameters:

--- a/apps/templates/all_apps.yaml
+++ b/apps/templates/all_apps.yaml
@@ -1,6 +1,7 @@
 {{- $currentScope := . -}}
 {{- range $service, $settings := .Values.services }}
-{{ $settings := default (dict "enabled" true) $settings -}}
+{{- /* Make sure settings is an empty dict if it is currently nil */ -}}
+{{ $settings := default dict $settings -}}
 {{ if ne $settings.removed true }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -30,12 +31,10 @@ spec:
           path: config/{{ . }}
       {{- end -}}
       {{- end }}
-      {{- if eq $settings.enabled false }}
       parameters:
         - name: global.enabled
-          value: {{ $settings.enabled | quote }}
-      {{- end -}}
-      {{ if $settings.values }}
+          value: {{ eq $settings.enabled false | ternary false true | quote }}
+      {{- if $settings.values }}
       values: |
 {{ toYaml $settings.values | indent 8 }}
       {{- end }}

--- a/apps/templates/all_apps.yaml
+++ b/apps/templates/all_apps.yaml
@@ -16,7 +16,7 @@ spec:
     name: {{ $currentScope.Values.destination.name }}
   source:
     repoURL: {{ default $currentScope.Values.source.repoURL $settings.repoURL }}
-    path: services/$service
+    path: {{ services/$service }}
     targetRevision: {{ default $currentScope.Values.source.targetRevision $settings.targetRevision }}
     helm:
       version: v3

--- a/apps/templates/all_apps.yaml
+++ b/apps/templates/all_apps.yaml
@@ -16,7 +16,7 @@ spec:
     name: {{ $currentScope.Values.destination.name }}
   source:
     repoURL: {{ default $currentScope.Values.source.repoURL $settings.repoURL }}
-    path: {{ "services/"$service }}
+    path: "services/"{{ $service }}
     targetRevision: {{ default $currentScope.Values.source.targetRevision $settings.targetRevision }}
     helm:
       version: v3

--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -45,10 +45,9 @@ services:
       P: BL45P-EA-DIFF-01
       ID: bl45p-ea-detector-02
 
-
   bl45p-mo-panda-01:
-    files: ["start.sh", "stop.sh", "liveness.sh"]
+    files: ["stop.sh", "liveness.sh", "start.sh"]
   bl45p-mo-panda-02:
-    files: ["start.sh", "stop.sh", "liveness.sh"]
+    files: ["stop.sh", "liveness.sh", "start.sh"]
   bl45p-mo-brick-01:
     files: ["ioc.yaml"]

--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -33,8 +33,8 @@ services:
   bl45p-ea-dcam-01:
   bl45p-ea-dcam-02:
   bl45p-mo-panda-01:
-    files: ["start.sh"]
+    files: ["start.sh", "liveness.sh", "stop.sh"]
   bl45p-mo-panda-02:
-    files: ["start.sh"]
+    files: ["start.sh", "liveness.sh", "stop.sh"]
   bl45p-mo-brick-01:
     files: ["ioc.yaml"]

--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -21,6 +21,8 @@ source:
 #            the path is always services/<service> within that repo
 #   enabled: set to false to turn off an IOC
 #   removed: set to true to remove the app from cluster
+#   files: list of files from the service's config folder to be made into
+#          fileParameters to helm
 
 services:
   # shared epics services ######################################################

--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -30,21 +30,8 @@ services:
 
   # epics iocs #################################################################
 
-  # example of epics templating in a local shared folder
   bl45p-ea-dcam-01:
-    files: ["ioc.yaml"]
-    folder: dls-aravis
-    values:
-      P: BL45P-EA-MAP-01
-      ID: bl45p-ea-detector-01
-
   bl45p-ea-dcam-02:
-    files: ["ioc.yaml"]
-    folder: dls-aravis
-    values:
-      P: BL45P-EA-DIFF-01
-      ID: bl45p-ea-detector-02
-
   bl45p-mo-panda-01:
     files: ["start.sh"]
   bl45p-mo-panda-02:

--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -46,8 +46,8 @@ services:
       ID: bl45p-ea-detector-02
 
   bl45p-mo-panda-01:
-    files: ["stop.sh", "liveness.sh", "start.sh"]
+    files: ["start.sh"]
   bl45p-mo-panda-02:
-    files: ["stop.sh", "liveness.sh", "start.sh"]
+    files: ["start.sh"]
   bl45p-mo-brick-01:
     files: ["ioc.yaml"]

--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -1,3 +1,11 @@
+# This file configures an ArgoCD app of apps that represent a beamline or
+# group of accelerator IOCs and services. The details of the services are
+# configured in the separate repo indicated by repoURL.
+
+# This repostory only controls which services and which versions of those
+# services should be running on the cluster. It is recommended that this repo
+# be updated by a CI/CD pipeline or configuration tools only.
+
 project: bl45p
 destination:
   name: pollux
@@ -8,13 +16,11 @@ source:
 
 # list of services to deploy. Each item is of the form:
 # - service: service name as it appears in K8S (statefulset/deployment name)
-#   enabled: set to false to turn off an IOC
 #   targetRevision: optional override for targetRevision above
-#   repoURL: optional override for helm chart repo or git repo
-#   chart: chart name if above is a helm repo (needs a token so let's not)
-#   folder: a subfolder of /services, defaults  /services/service_name
-#       used this for shared, templated charts and add some values to customize
-#   values: A dict of key:value to pass as parameters to the target chart
+#   repoURL: optional override for git repo to source the helm chart from
+#            the path is always services/<service> within that repo
+#   enabled: set to false to turn off an IOC
+#   removed: set to true to remove the app from cluster
 
 services:
   # shared epics services ######################################################

--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -31,6 +31,7 @@ services:
   # epics iocs #################################################################
 
   bl45p-ea-dcam-01:
+    enabled: false
   bl45p-ea-dcam-02:
   bl45p-mo-panda-01:
     files: ["start.sh", "liveness.sh", "stop.sh"]


### PR DESCRIPTION
- this PR simplifies bl45p-apps so that is responsible for which services and which versions of those services are running in the cluster only
- see matching PR for bl45p https://github.com/epics-containers/bl45p/pull/24

note that this repo still must pass 'global.files' to the fileParameters to helm. This is sub-optimal and we should investigate ways to move this down into the bl45p services project, then all service config is self contained. However this may prove hard to do.